### PR TITLE
Add temporary redirect to GitHub repository

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,8 +1,7 @@
 # wafer.space End User Documentation
 
-```{toctree}
----
-maxdepth: 3
----
-useful-resources
+```{raw} html
+<meta http-equiv="refresh" content="0; url=https://github.com/wafer-space">
 ```
+
+Redirecting to [https://github.com/wafer-space](https://github.com/wafer-space)...


### PR DESCRIPTION
## Summary
- Modified the index page to redirect visitors to https://github.com/wafer-space
- Uses HTML meta refresh tag for immediate redirection
- Displays fallback link in case redirect doesn't work automatically

## Test plan
- [ ] Build the documentation locally with `make html`
- [ ] Open `_build/index.html` in a browser and verify it redirects to the GitHub repository
- [ ] Verify the fallback link is clickable if JavaScript is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)